### PR TITLE
Change X-XSS-Protection "1; block" -> "0" default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ secure_cookie = SecureCookie()
 ```HTTP
 Strict-Transport-Security: max-age=63072000; includeSubdomains
 X-Frame-Options: SAMEORIGIN
-X-XSS-Protection: 1; mode=block
+X-XSS-Protection: 0
 X-Content-Type-Options: nosniff
 Referrer-Policy: no-referrer, strict-origin-when-cross-origin
 Cache-control: no-cache, no-store, must-revalidate, max-age=0

--- a/docs/source/frameworks.rst
+++ b/docs/source/frameworks.rst
@@ -18,7 +18,7 @@ Framework Agnostic
 
 **Return Value:**
 
-``{'Strict-Transport-Security': 'max-age=63072000; includeSubdomains', 'X-Frame-Options': 'SAMEORIGIN', 'X-XSS-Protection': '1; mode=block', 'X-Content-Type-Options': 'nosniff', 'Content-Security-Policy': "script-src 'self'; object-src 'self'", 'Referrer-Policy': 'no-referrer, strict-origin-when-cross-origin', 'Cache-control': 'no-cache, no-store, must-revalidate', 'Pragma': 'no-cache', 'Feature-Policy': "accelerometer 'none'; ambient-light-sensor 'none'; autoplay 'none'; camera 'none'; encrypted-media 'none';fullscreen 'none'; geolocation 'none'; gyroscope 'none'; magnetometer 'none'; microphone 'none'; midi 'none';payment 'none'; picture-in-picture 'none'; speaker 'none'; sync-xhr 'none'; usb 'none'; vr 'none';"}``
+``{'Strict-Transport-Security': 'max-age=63072000; includeSubdomains', 'X-Frame-Options': 'SAMEORIGIN', 'X-XSS-Protection': '0', 'X-Content-Type-Options': 'nosniff', 'Content-Security-Policy': "script-src 'self'; object-src 'self'", 'Referrer-Policy': 'no-referrer, strict-origin-when-cross-origin', 'Cache-control': 'no-cache, no-store, must-revalidate', 'Pragma': 'no-cache', 'Feature-Policy': "accelerometer 'none'; ambient-light-sensor 'none'; autoplay 'none'; camera 'none'; encrypted-media 'none';fullscreen 'none'; geolocation 'none'; gyroscope 'none'; magnetometer 'none'; microphone 'none'; midi 'none';payment 'none'; picture-in-picture 'none'; speaker 'none'; sync-xhr 'none'; usb 'none'; vr 'none';"}``
 
 
 aiohttp

--- a/docs/source/headers.rst
+++ b/docs/source/headers.rst
@@ -34,8 +34,8 @@ X-Frame-Options (XFO)
 X-XSS-Protection
 ^^^^^^^^^^^^^^^^^^
 
-| Enable browser cross-site scripting filters
-| **Default Value:** ``1; mode=block``
+| Disable browser cross-site scripting filters
+| **Default Value:** ``0``
 
 X-Content-Type-Options
 ^^^^^^^^^^^^^^^^^^^^^^^
@@ -88,7 +88,7 @@ Usage
 
    Strict-Transport-Security: max-age=63072000; includeSubdomains
    X-Frame-Options: SAMEORIGIN
-   X-XSS-Protection: 1; mode=block
+   X-XSS-Protection: 0
    X-Content-Type-Options: nosniff
    Referrer-Policy: no-referrer, strict-origin-when-cross-origin
    Cache-control: no-cache, no-store, must-revalidate, max-age=0

--- a/docs/source/headers.rst
+++ b/docs/source/headers.rst
@@ -34,7 +34,7 @@ X-Frame-Options (XFO)
 X-XSS-Protection
 ^^^^^^^^^^^^^^^^^^
 
-| Disable browser cross-site scripting filters
+| Enable browser cross-site scripting filters
 | **Default Value:** ``0``
 
 X-Content-Type-Options

--- a/docs/source/policies.rst
+++ b/docs/source/policies.rst
@@ -224,7 +224,7 @@ Response Headers:
 
    Strict-Transport-Security: includeSubDomains; preload; max-age=2592000
    X-Frame-Options: deny
-   X-XSS-Protection: 1; mode=block
+   X-XSS-Protection: 0
    X-Content-Type-Options: nosniff
    Content-Security-Policy: default-src 'none'; base-uri 'self'; block-all-mixed-content; connect-src 'self' api.spam.com; frame-src 'none'; img-src 'self' static.spam.com
    Referrer-Policy: no-referrer

--- a/secure/headers.py
+++ b/secure/headers.py
@@ -29,7 +29,7 @@ class Security_Headers:
     x_xss_protection = Header(
         header="X-XSS-Protection",
         value="0",
-        info="Disable browser Cross-Site Scripting filters",
+        info="Enable browser Cross-Site Scripting filters",
     )
 
     x_content_type_options = Header(

--- a/secure/headers.py
+++ b/secure/headers.py
@@ -28,8 +28,8 @@ class Security_Headers:
 
     x_xss_protection = Header(
         header="X-XSS-Protection",
-        value="1; mode=block",
-        info="Enable Cross-Site Scripting filters",
+        value="0",
+        info="Disable browser Cross-Site Scripting filters",
     )
 
     x_content_type_options = Header(


### PR DESCRIPTION
By https://github.com/OWASP/CheatSheetSeries/issues/376#issuecomment-602663932:

> I've been studying this issue for a while and it's *dangerous* to set this header. It makes sites that are not vulnerable to XSS, vulnerable.
> ...
> Developers need to either remove the header or set it to zero, I think the debate is over. There is NO good reason to set this header to blocking mode.

Also see https://github.com/github/secure_headers/issues/439, https://github.com/helmetjs/helmet/issues/230

Seen suggest remove vs. "0" by https://github.com/helmetjs/helmet/issues/230#issuecomment-614106165:

> The recommendation as a security community is to have a default value of 0 so that browsers don't set their own defaults.

and by https://owasp.org/www-project-secure-headers/#x-xss-protection:

> Warning: The X-XSS-Protection header has been deprecated by modern browsers and its use can introduce additional security issues on the client side. As such, it is recommended to set the header as X-XSS-Protection: 0 in order to disable the XSS Auditor, and not allow it to take the default behavior of the browser handling the response. Please use Content-Security-Policy instead.